### PR TITLE
allow server process to be stopped

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Rewriting the basic PDF functionality means:
 ```elixir
   # Load image, get alias
   {alpaca_alias, alpaca_rendition} = Gutenex.PDF.Images.load("./test/support/images/alpaca.png")
-  
+
   {:ok, pid} = Gutenex.start_link
   Gutenex.add_image(pid, alpaca_alias, alpaca_rendition)
     |> Gutenex.begin_text
@@ -45,6 +45,7 @@ Rewriting the basic PDF functionality means:
       translate_y: 500,
     })
     |> Gutenex.export("./tmp/alpaca.pdf")
+    |> Gutenex.stop
 ```
 
 Now open up that file and you should see some text near the bottom and a picture

--- a/lib/gutenex.ex
+++ b/lib/gutenex.ex
@@ -30,6 +30,13 @@ defmodule Gutenex do
   #######################
 
   @doc """
+  Stop the server process
+  """
+  def stop(pid) do
+    GenServer.call(pid, :stop)
+  end
+
+  @doc """
   Returns the current context
   """
   def context(pid) do
@@ -91,7 +98,7 @@ defmodule Gutenex do
     GenServer.cast(pid, {:text, :write_br, text_to_write})
     pid
   end
-  
+
   @doc """
   Set line space
   """
@@ -99,7 +106,7 @@ defmodule Gutenex do
     GenServer.cast(pid, {:text, :line_spacing, size})
     pid
   end
-  
+
   @doc """
   End a text block
   """
@@ -209,6 +216,12 @@ defmodule Gutenex do
   ##   Call handlers   ##
   #######################
 
+  @doc """
+  Handles stopping the server process
+  """
+  def handle_call(:stop, _from, state) do
+    {:stop, :normal, :ok, state}
+  end
 
   @doc """
   Returns the current context
@@ -298,7 +311,7 @@ defmodule Gutenex do
     stream = stream <> Text.line_spacing(size)
     {:noreply, [context, stream]}
   end
-  
+
   @doc """
     Set the text position
   """

--- a/test/gutenex_test.exs
+++ b/test/gutenex_test.exs
@@ -6,6 +6,15 @@ defmodule GutenexTest do
     {:ok, %{server: server_pid}}
   end
 
+  test "can stop server" do
+    {:ok, server_pid} = Gutenex.start_link()
+    assert Process.alive? server_pid
+
+    :ok = Gutenex.stop(server_pid)
+
+    assert !Process.alive? server_pid
+  end
+
   test "getting the context", %{server: server} do
     assert %Gutenex.PDF.Context{} == Gutenex.context(server)
   end


### PR DESCRIPTION
Hi There! There seems to be no way to stop the server process right now so I added a new function to do so along with corresponding unit tests.

To give a little detail, my use case is generating pdf docs within http requests. If there is some better way to handle this please let me know.

Feedback is welcome :)