### PR TITLE
Specify more strict imagineer version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Gutenex.Mixfile do
 
   defp deps do
     [
-      {:imagineer, "~> 0.1" },
+      {:imagineer, "~> 0.1.0" },
       {:apex, "~>0.3.0" },
       {:earmark, "~> 0.1", only: :dev},
       {:ex_doc, "~> 0.6", only: :dev }


### PR DESCRIPTION
Hi,
When I added the library to my project I got this compilation error:
```elixir
==> gutenex
Compiled lib/gutenex/geometry.ex
Compiled lib/gutenex/geometry/bezier.ex
lib/gutenex/geometry/bezier.ex:2: warning: unused import Gutenex.Geometry
Compiled lib/gutenex/geometry/line.ex
Compiled lib/gutenex/geometry/rectangle.ex
lib/gutenex/geometry/rectangle.ex:2: warning: unused import Gutenex.Geometry
Compiled lib/gutenex/pdf/font.ex
Compiled lib/gutenex/pdf/graphics.ex

== Compilation error on file lib/gutenex/pdf/images.ex ==
** (CompileError) lib/gutenex/pdf/images.ex:5: Imagineer.Image.__struct__/0 is undefined, cannot expand struct Imagineer.Image
    (elixir) src/elixir_map.erl:58: :elixir_map.translate_struct/4
    (stdlib) lists.erl:1353: :lists.mapfoldl/3
    (stdlib) lists.erl:1354: :lists.mapfoldl/3
```
It was trying to use `imagineer` `0.2.1`. Locking it to `0.1.0` solve the issue.