### PR TITLE
expose line drawing, add line_width

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,12 @@ Rewriting the basic PDF functionality means:
 
 Now open up that file and you should see some text near the bottom and a picture
 of what I believe to be an alpaca. Could also be a llama.
+
+By default, coordinates are in units of 1/72 inch as per the PDF
+spec. Origin is in lower left corner of the page. This is roughly 1
+point in printing terms.
+
+```
+  Gutenex.line_width(pid, 0.01)          # very fine line
+  |> Gutenex.line({{0, 0}, {500, 500}})  # up and to the right
+```

--- a/lib/gutenex.ex
+++ b/lib/gutenex.ex
@@ -212,6 +212,16 @@ defmodule Gutenex do
     pid
   end
 
+  def line(pid, {point_start, point_finish}) do
+    GenServer.cast(pid, {:geometry, :line, {point_start, point_finish}})
+    pid
+  end
+
+  def line_width(pid, width) do
+    GenServer.cast(pid, {:geometry, :line_width, width})
+    pid
+  end
+
   #######################
   ##   Call handlers   ##
   #######################
@@ -383,6 +393,16 @@ defmodule Gutenex do
 
   def handle_cast({:geometry, :move_to, {point_x, point_y}}, [context, stream]) do
     stream = stream <> Geometry.move_to({point_x, point_y})
+    {:noreply, [context, stream]}
+  end
+
+  def handle_cast({:geometry, :line, {point_start, point_finish}}, [context, stream]) do
+    stream = stream <> Geometry.Line.line({point_start, point_finish})
+    {:noreply, [context, stream]}
+  end
+
+  def handle_cast({:geometry, :line_width, width}, [context, stream]) do
+    stream = stream <> Geometry.Line.line_width(width)
     {:noreply, [context, stream]}
   end
 end

--- a/lib/gutenex/geometry/line.ex
+++ b/lib/gutenex/geometry/line.ex
@@ -1,6 +1,10 @@
 defmodule Gutenex.Geometry.Line do
   import Gutenex.Geometry
 
+  def line_width(number) do
+    "#{number} w q "
+  end
+
   def line({from_point, to_point}) do
     move_to(from_point) <>
     draw_line(to_point) <>


### PR DESCRIPTION
I saw that you had functions for drawing lines, but I couldn't figure out how to use them in the same paradigm as everything else. I added similar functions to the Gutenex module so I could access them. Then I noticed there was no way to control line width, so I looked up how to do that and added some similar functions for that.

Example usage:

```
    {:ok, pid} = Gutenex.start_link
    Gutenex.line_width(pid, 0.5)
    |> Gutenex.line({{0,0}, {90, 100}})
    |> Gutenex.line_width(0.75)
    |> Gutenex.line({{0,10}, {90, 110}})
    |> Gutenex.line_width(1)
    |> Gutenex.line({{0,20}, {90, 120}})
    |> Gutenex.export("./tmp/template.pdf")
    |> Gutenex.stop
```

At this point I can do what I want - I want to make some templates for practicing calligraphy with horizontal lines and lines at an angle. 