### PR TITLE
Add flate filter

### DIFF
--- a/lib/gutenex/pdf/filter.ex
+++ b/lib/gutenex/pdf/filter.ex
@@ -1,0 +1,40 @@
+defmodule Gutenex.PDF.Filter do
+
+  # returns compressed bytes, updated dictionary
+  def flate(stream_content, stream_dict) do
+
+
+    # the original size can be passed as "DL" 
+    # in the stream dictionary
+    # original_size = byte_size(stream_content)
+    
+    # deflate the stream contents
+    z = :zlib.open()
+    :zlib.deflateInit(z)
+    zout = :zlib.deflate(z, stream_content)
+    compressed = IO.iodata_to_binary(zout)
+    :zlib.close(z)
+
+    new_dict = stream_dict
+               |> Map.put("Length", byte_size(compressed))
+               |> add_filter("FlateDecode")
+    {compressed, new_dict}
+  end
+
+  # TODO: also need to correctly handle DecodeParams, if any
+  defp add_filter(stream_dict, filter_name) do
+    existing = Map.get(stream_dict, "Filter")
+
+    # multiple filters are treated as an array
+    # filters are added to the head when encoding
+    # so decoder can simply iterate over list of filters
+    filter_val = case existing do
+      nil -> {:name, filter_name}
+      {:name, orig} -> {:array, [{:name, filter_name}, {:name, orig}]}
+      {:array, list} -> {:array, [{:name, filter_name} | list]}
+    end
+
+    stream_dict
+    |> Map.put("Filter", filter_val)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -20,9 +20,9 @@ defmodule Gutenex.Mixfile do
 
   defp deps do
     [
-      {:imagineer, "~> 0.1" },
-      {:earmark, "~> 0.1", only: :dev},
-      {:ex_doc, "~> 0.6", only: :dev }
+      {:imagineer, "~> 0.2.1" },
+      {:earmark, "~> 1.0.2", only: :dev},
+      {:ex_doc, "~> 0.14.3", only: :dev }
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,4 @@
 %{"apex": {:hex, :apex, "0.3.7", "0e4b39ff34d740da9898e368995fdaab2fe4d2a444a6bbe23ccffb3c6978b92c", [:mix], []},
-  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
-  "erlguten": {:git, "git://github.com/SenecaSystems/erlguten.git", "c02b8fc57571615837b4b369cef3fecaa609436b", []},
-  "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
+  "earmark": {:hex, :earmark, "1.0.2", "a0b0904d74ecc14da8bd2e6e0248e1a409a2bc91aade75fcf428125603de3853", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "imagineer": {:hex, :imagineer, "0.2.1", "b426707d1c8326cab81ce4d3f5e029283776a7b806db9dbc51306eb2e1451aa6", [:mix], [{:apex, "~>0.3.2", [hex: :apex, optional: false]}]}}


### PR DESCRIPTION
This adds the ability to filter stream contents on write -- in particular it implements the widely used zlib/deflate compression method widely used for embedding binary contents such as fonts.

Please note that Travis cannot build this branch until #12 is merged.
